### PR TITLE
Make license a valid SPDX license expression

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "https://github.com/datastax/pulsar-admin-console.git"
   },
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "dependencies": {
     "awesome-bootstrap-checkbox": "1.0.0-alpha.5",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
When running `npm install`, I discovered that it was logging the following error:

```text
warn vuestic-admin@1.9.0 license should be a valid SPDX license expression
```

It looks like the SPDX expressions are defined here: https://spdx.org/licenses/. This PR updates the console to use a valid license string.