### PR TITLE
Add support for OpenID Connect Token Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # Pulsar Admin Console
 
 Pulsar Admin Console is a web based UI that administrates topics, namespaces, sources, sinks and various aspects of Apache Pulsar features.
+
+## Auth Modes
+There are three available configurations for `auth_mode`: `none`, `k8s`, and `openidconnect`.
+
+### Auth Mode: OpenID Connect
+In this auth mode, the dashboard will use your login credentials to attempt to retrieve a JWT from an authentication
+provider. In the [DataStax Pulsar Helm Chart](https://github.com/datastax/pulsar-helm-chart), this is implemented by
+integrating the Pulsar Admin Console with Keycloak. Upon successful retrieval of the JWT, the Pulsar Admin Console will
+use the retrieved JWT as the bearer token when making calls to Pulsar.
+
+In addition to configuring the `auth_mode`, you also need to configure the `oauth_client_id`. This is the client id that
+the Console will use when authenticating with Keycloak. Note that in Keycloak, it is important that this client exists
+and that it has the `sub` claim properly mapped to your desired Pulsar subject. Otherwise, the JWT won't work as desired.
+
 ### Dev
 #### Node and NPM version
 Use these versions of node and npm:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ In addition to configuring the `auth_mode`, you also need to configure the `oaut
 the Console will use when authenticating with Keycloak. Note that in Keycloak, it is important that this client exists
 and that it has the `sub` claim properly mapped to your desired Pulsar subject. Otherwise, the JWT won't work as desired.
 
+#### Connecting to an OpenID Connect Auth/Identity Provider
+When opening the Console, the first page is the login page. When using the `openidconnect` auth mode, the auth call
+needs to go to the Provider's server. In the current design, nginx must be configured to route the call to the provider.
+The [DataStax Pulsar Helm Chart](https://github.com/datastax/pulsar-helm-chart) does this automatically.
+
 ### Dev
 #### Node and NPM version
 Use these versions of node and npm:

--- a/dashboard/public/config.js
+++ b/dashboard/public/config.js
@@ -59,6 +59,7 @@ var globalConf = {
     "running_env": "k8s",
     "use_token_list": "false",
     "auth_mode": "none",
+    "oauth_client_id": "",
     "host_overrides": {
         "pulsar": "http://localhost:6650",
         "ws": "ws://localhost:8080",

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -25,7 +25,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { isK8sAuthRequired, isLoggedIn } from './components/auth/login/auth.js'
+import { isAuthRequired, isLoggedIn } from './components/auth/login/auth.js'
 export default {
   name: 'app',
   data () {
@@ -53,7 +53,7 @@ export default {
 
       // Get data injected 
       console.log(globalConf);
-      console.log(isK8sAuthRequired())
+      console.log(isAuthRequired())
       console.log(isLoggedIn())
 
       if (typeof overrideConf !== 'undefined' && overrideConf) {
@@ -88,6 +88,7 @@ export default {
       this.$store.commit('setDisableBilling', globalConf.disable_billing)
       this.$store.commit('setRunningEnv', globalConf.running_env)
       this.$store.commit('setAuthMode', globalConf.auth_mode)
+      this.$store.commit('setOauthClientId', globalConf.oauth_client_id)
       this.$store.commit('setLogin', globalConf.login)
       this.$store.commit('setEmail', globalConf.email)
       this.$store.commit('setHostOverrides', globalConf.host_overrides)

--- a/dashboard/src/components/admin/app-navbar/AppNavbar.vue
+++ b/dashboard/src/components/admin/app-navbar/AppNavbar.vue
@@ -198,6 +198,7 @@ export default {
       'tenantList',
       'runningEnv',
       'authMode',
+      'oauthClientId',
       'login'
     ]),
     availableClusters () {

--- a/dashboard/src/router/index.js
+++ b/dashboard/src/router/index.js
@@ -20,7 +20,7 @@ import Router from 'vue-router'
 import AppLayout from '../components/admin/AppLayout'
 import Login from '../components/auth/login/Login'
 import AuthLayout from '../components/auth/AuthLayout'
-import { isK8sAuthRequired, isLoggedIn } from '../components/auth/login/auth.js'
+import { isAuthRequired, isLoggedIn } from '../components/auth/login/auth.js'
 // import { isLoggedIn } from '../auth/auth'
 // import WelcomeLayout from '../components/welcome/WelcomeLayout'
 import lazyLoading from './lazyLoading'
@@ -339,7 +339,7 @@ const router = new Router({
 })
 
 router.beforeEach((to, from, next) => {
-  if (isK8sAuthRequired() && !to.meta.allowAnonymous && !isLoggedIn()) {
+  if (isAuthRequired() && !to.meta.allowAnonymous && !isLoggedIn()) {
     next({
       path: '/auth/login',
       query: { redirect: to.fullPath }

--- a/dashboard/src/services/ApiBase.js
+++ b/dashboard/src/services/ApiBase.js
@@ -17,16 +17,16 @@
 
 import axios from 'axios'
 import store from '../store/index'
+import { getAuthToken } from '../components/auth/login/auth.js'
 
 export default() => {
-  const adminToken = store.getters.adminToken
   return axios.create({
     baseURL: store.getters.apiBaseUrl,
     withCredentials: false,
     timeout: 4500,
     headers: {
       'Accept': 'application/json',
-      'Authorization': `Bearer ${adminToken}`
+      'Authorization': `Bearer ${getAuthToken()}`
     }
   })
 }

--- a/dashboard/src/services/ApiBaseV2.js
+++ b/dashboard/src/services/ApiBaseV2.js
@@ -17,16 +17,16 @@
 
 import axios from 'axios'
 import store from '../store/index'
+import { getAuthToken } from '../components/auth/login/auth.js'
 
 export default() => {
-  const adminToken = store.getters.adminToken
   return axios.create({
     baseURL: store.getters.apiBaseUrl.replace('v1', 'v2'),
     withCredentials: false,
     timeout: 4500,
     headers: {
       'Accept': 'application/json',
-      'Authorization': `Bearer ${adminToken}`
+      'Authorization': `Bearer ${getAuthToken()}`
     }
   })
 }

--- a/dashboard/src/store/modules/pulsar.js
+++ b/dashboard/src/store/modules/pulsar.js
@@ -56,6 +56,7 @@ const state = {
   disableBilling: 'false',
   runningEnv: 'web',
   authMode: 'none',
+  oauthClientId: '',
   planInfo: {},
   hostOverrides: {},
   subscriptionInfo: [],
@@ -145,6 +146,9 @@ const mutations = {
   },
   setAuthMode (state, value) {
     state.authMode = value
+  },  
+  setOauthClientId (state, value) {
+    state.oauthClientId = value
   },
   setChargebeeSite (state, site) {
     state.chargebeeSite = site
@@ -485,6 +489,7 @@ const getters = {
   disableBilling: state => state.disableBilling,
   runningEnv: state => state.runningEnv,
   authMode: state => state.authMode,
+  oauthClientId: state => state.oauthClientId,
   chargebeeSite: state => state.chargebeeSite,
   billingProvider: state => state.billingProvider,
   userRole: state => state.userRole,

--- a/server/config.js
+++ b/server/config.js
@@ -61,7 +61,7 @@ const generateIndexHtml = (indexHtml) => {
 
     let overrideConfig = {}
 
-    if (dashboardConfig.token_path) {
+    if (dashboardConfig.token_path && (dashboardConfig.auth_mode === 'none' || dashboardConfig.auth_mode === 'k8s')) {
         
         const token = fs.readFileSync(dashboardConfig.token_path, "utf8")
         overrideConfig.admin_token = token.trim()

--- a/server/server.js
+++ b/server/server.js
@@ -73,7 +73,8 @@ app.post('/api/v1/auth/token', async (req, res) => {
       let result = await k8s.authenticate(username, password);
       if (result) {
         const secret = process.env.TOKEN_SECRET || "default-secret"
-        res.send({token: jwt.sign({user: username}, secret, {expiresIn: '1d'})});
+        // This loosely complies with https://openid.net/specs/openid-connect-core-1_0.html section 3.2.2.5. Successful Authentication Response
+        res.send({access_token: jwt.sign({user: username}, secret, {expiresIn: '1d'})});
         return;
       }
     }


### PR DESCRIPTION
This PR adds support for integrating the Pulsar Admin Console and Keycloak. It will technically work with any OpenID Connect authentication/identity provider.

### Additions
* Added new `auth_mode` named `openidconnect`. When configured, users will be expected to authenticate with an authentication/identity provider. We will rely on configuring the `nginx.conf` to redirect calls to the proper upstream server here. Specifically, calls to the `/api/v1/auth/token` endpoint will need to be directed to the right endpoint.
* Added the `oauth_client_id` setting. This client id is the one to use when retrieving the JWT. 

@cdbartholomew - is the client id something we would want to ask users to provide when they sign in? If not, all users will get tokens for the one, configured client id, which means signing into the PAC has only one permission level.

