### PR TITLE
Add client token to vuex store

### DIFF
--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -25,7 +25,7 @@
 
 <script>
 import { mapGetters } from 'vuex'
-import { isAuthRequired, isLoggedIn } from './components/auth/login/auth.js'
+import { getAuthToken, isAuthRequired, isLoggedIn } from './components/auth/login/auth.js'
 export default {
   name: 'app',
   data () {
@@ -70,7 +70,12 @@ export default {
       this.$store.commit('updateAllowedClusters', allowClusterList)
       this.$store.commit('updateNumAllowedClusters', allowClusterList.length)
 
-      this.$store.commit('setClientToken', globalConf.client_token)
+      // If unexpired token is stored in local storage, use that one.
+      if (isLoggedIn()) {
+        this.$store.commit('setClientToken', getAuthToken())
+      } else {
+        this.$store.commit('setClientToken', globalConf.client_token)
+      }
       this.$store.commit('setPlan', globalConf.plan)
       this.$store.commit('setAdminToken', globalConf.admin_token)
       this.$store.commit('setApiBaseUrl', globalConf.api_base_url)

--- a/dashboard/src/components/auth/login/auth.js
+++ b/dashboard/src/components/auth/login/auth.js
@@ -67,6 +67,8 @@ export function setAuthToken(token) {
     axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
     console.log('set token', token)
     localStorage.setItem(AUTH_TOKEN_KEY, token)
+    // Add to vuex, as it is retrieved from there to make many calls
+    store.commit('setClientToken', token)
 }
 
 export function getAuthToken() {
@@ -76,6 +78,7 @@ export function getAuthToken() {
 export function clearAuthToken() {
     axios.defaults.headers.common['Authorization'] = ''
     localStorage.removeItem(AUTH_TOKEN_KEY)
+    store.commit('setClientToken', null)
 }
 
 export function isLoggedIn() {

--- a/dashboard/src/components/clients/PulsarClient.vue
+++ b/dashboard/src/components/clients/PulsarClient.vue
@@ -232,7 +232,7 @@ export default {
       connectError: false,
       consumerInterface: true,
       earliestMessages: true,
-      errorText: 'Error detected with client connnection. Try again.'
+      errorText: 'Error detected with client connection. Try again.'
     }
   },
   components: {

--- a/dashboard/src/services/ApiBase.js
+++ b/dashboard/src/services/ApiBase.js
@@ -17,7 +17,6 @@
 
 import axios from 'axios'
 import store from '../store/index'
-import { getAuthToken } from '../components/auth/login/auth.js'
 
 export default() => {
   return axios.create({
@@ -26,7 +25,7 @@ export default() => {
     timeout: 4500,
     headers: {
       'Accept': 'application/json',
-      'Authorization': `Bearer ${getAuthToken()}`
+      'Authorization': `Bearer ${store.getters.clientToken}`
     }
   })
 }

--- a/dashboard/src/services/ApiBaseV2.js
+++ b/dashboard/src/services/ApiBaseV2.js
@@ -17,7 +17,6 @@
 
 import axios from 'axios'
 import store from '../store/index'
-import { getAuthToken } from '../components/auth/login/auth.js'
 
 export default() => {
   return axios.create({
@@ -26,7 +25,7 @@ export default() => {
     timeout: 4500,
     headers: {
       'Accept': 'application/json',
-      'Authorization': `Bearer ${getAuthToken()}`
+      'Authorization': `Bearer ${store.getters.clientToken}`
     }
   })
 }


### PR DESCRIPTION
The first implementation of the `openidconnect` auth mode was only partially correct. It should have included an update to the vuex store. This PR adds the missing functionality.