### PR TITLE
Remove monitoring tab; login on enter

### DIFF
--- a/dashboard/public/config.js
+++ b/dashboard/public/config.js
@@ -55,6 +55,7 @@ var globalConf = {
     "multi_user_org": "",
     "private_org": "true",
     "functions_disabled": "false",
+    "render_monitoring_tab": "false",
     "clients_disabled": "false",
     "running_env": "k8s",
     "use_token_list": "false",

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -119,6 +119,10 @@ export default {
         this.$store.commit('setFunctionsDisabled', globalConf.functions_disabled)
       }
 
+      if (globalConf.rende_monitoring_tab === 'true') {
+        this.$store.commit('setRenderMonitoringTab', globalConf.rende_monitoring_tab)
+      }
+
       if (globalConf.clients_disabled === 'true') {
         this.$store.commit('setClientsDisabled', globalConf.clients_disabled)
       }

--- a/dashboard/src/App.vue
+++ b/dashboard/src/App.vue
@@ -119,8 +119,8 @@ export default {
         this.$store.commit('setFunctionsDisabled', globalConf.functions_disabled)
       }
 
-      if (globalConf.rende_monitoring_tab === 'true') {
-        this.$store.commit('setRenderMonitoringTab', globalConf.rende_monitoring_tab)
+      if (globalConf.render_monitoring_tab === 'true') {
+        this.$store.commit('setRenderMonitoringTab', globalConf.render_monitoring_tab)
       }
 
       if (globalConf.clients_disabled === 'true') {

--- a/dashboard/src/components/admin/app-sidebar/AppSidebar.vue
+++ b/dashboard/src/components/admin/app-sidebar/AppSidebar.vue
@@ -183,13 +183,12 @@
             <span>Brokers</span>
           </span>
         </sidebar-link>
-<!-- Temporarily removed becuase grafana is already externally accessible. Might permanently remove lated.
-        <sidebar-link
+        <sidebar-link v-if="this.renderMonitoringTab === 'true'"
           :to="{ name: 'clusterMonitor' }">
           <span slot="title">
             <span>Monitoring</span>
           </span>
-        </sidebar-link> -->
+        </sidebar-link>
         <sidebar-link
           :to="{ name: 'clusterDetail' }">
           <span slot="title">
@@ -249,6 +248,7 @@ export default {
       'featureFlags',
       'disableBilling',
       'privateOrg',
+      'renderMonitoringTab',
       'functionsDisabled',
       'clientsDisabled',
       'isAdminUser',

--- a/dashboard/src/components/admin/app-sidebar/AppSidebar.vue
+++ b/dashboard/src/components/admin/app-sidebar/AppSidebar.vue
@@ -183,12 +183,13 @@
             <span>Brokers</span>
           </span>
         </sidebar-link>
+<!-- Temporarily removed becuase grafana is already externally accessible. Might permanently remove lated.
         <sidebar-link
           :to="{ name: 'clusterMonitor' }">
           <span slot="title">
             <span>Monitoring</span>
           </span>
-        </sidebar-link>
+        </sidebar-link> -->
         <sidebar-link
           :to="{ name: 'clusterDetail' }">
           <span slot="title">

--- a/dashboard/src/components/auth/login/Login.vue
+++ b/dashboard/src/components/auth/login/Login.vue
@@ -24,7 +24,7 @@
     <!-- form method="post" action="/auth/login" name="login" -->
       <div class="form-group">
         <div class="input-group">
-          <input type="text" id="email" required="required" v-model="email"/>
+          <input type="text" id="email" required="required" v-model="email" v-on:keyup.enter="login"/>
           <label class="control-label" for="email">
             Username
           </label>
@@ -33,7 +33,7 @@
       </div>
       <div class="form-group">
         <div class="input-group">
-          <input type="password" id="password" required="required" v-model="password"/>
+          <input type="password" id="password" required="required" v-model="password" v-on:keyup.enter="login"/>
           <label class="control-label" for="password">
             {{ $t('auth.password') }}
           </label>

--- a/dashboard/src/store/modules/pulsar.js
+++ b/dashboard/src/store/modules/pulsar.js
@@ -78,6 +78,7 @@ const state = {
   useTokenList: 'false',
   brokerLoadData: {},
   functionsDisabled: 'false',
+  renderMonitoringTab: 'false',
   clientsDisabled: 'false',
   userRole: 'admin',
   featureFlags: '',
@@ -114,6 +115,9 @@ const mutations = {
   },
   setFunctionsDisabled (state, flag) {
     state.functionsDisabled = flag
+  },
+  setRenderMonitoringTb (state, flag) {
+    state.renderMonitoringTab = flag
   },
   setClientsDisabled (state, flag) {
     state.clientsDisabled = flag
@@ -475,6 +479,7 @@ const getters = {
   email: state => state.email,
   multiUserOrg: state => state.multiUserOrg,
   functionsDisabled: state => state.functionsDisabled,
+  renderMonitoringTab: state => state.renderMonitoringTab,
   clientsDisabled: state => state.clientsDisabled,
   privateOrg: state => state.privateOrg,
   useTokenList: state => state.useTokenList,

--- a/dashboard/src/store/modules/pulsar.js
+++ b/dashboard/src/store/modules/pulsar.js
@@ -116,7 +116,7 @@ const mutations = {
   setFunctionsDisabled (state, flag) {
     state.functionsDisabled = flag
   },
-  setRenderMonitoringTb (state, flag) {
+  setRenderMonitoringTab (state, flag) {
     state.renderMonitoringTab = flag
   },
   setClientsDisabled (state, flag) {


### PR DESCRIPTION
Remove support for the monitor browser tab. Because I didn't remove the source code behind that browser tab, I only commented out the tab. @cdbartholomew, let me know if that works for you.

Make it so that you can either hit `enter` to login or click on the `login` button.