### PR TITLE
Optimize Docker Image to Reduce Size; Use npm ci to get dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@ Dockerfile*
 docker-compose*
 .dockerignore
 .git
-.gitignore
+**/.gitignore
 *.jwt
 README.md
 LICENSE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build vue components
         run: |
           cd dashboard
-          npm install
+          npm ci
           npm install -g @vue/cli 
           npm run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ WORKDIR /build
 
 COPY ./dashboard/ .
 
-# make sure node_modules is not copye although it should be skipped by .dockerignore
-RUN rm -rf node_modules
-RUN npm install
+# Prefer ci instead of install here
+RUN npm ci
+# Only need @vue/cli to run the "build-standalone" script. We don't need it in the final image.
 RUN npm install -g @vue/cli
 RUN npm run build-standalone
 RUN chmod -R g=u /build/dist
@@ -30,7 +30,7 @@ COPY --from=UI-BUILD --chown=10001:0 /build/dist/index.html /home/appuser/dashbo
 COPY --chown=10001:0 server/package*.json /home/appuser/server/
 COPY --chown=10001:0 server/*.js /home/appuser/server/
 COPY --chown=10001:0 server/*.html /home/appuser/server/
-RUN cd server && npm install
+RUN cd server && npm ci && npm cache clean --force
 
 WORKDIR /home/appuser/server
 


### PR DESCRIPTION
Our current docker image is build using `npm install`. This currently leads to caching dependencies unnecessarily. Further, it seems that we should prefer to build using `npm ci` as this will fail if there are any discrepancies between the `package.json` and the `package-lock.json` and it will delete an accidentally existing `node-modules` directory (`https://docs.npmjs.com/cli/v7/commands/npm-ci`). Finally, we were adding in unnecessary files, so I update the `.dockerignore` file.