### PR TITLE
Add tarball release artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# These artifacts are a byproduct of running `make tarball`
+dest/
+pulsar-admin-console-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,9 @@ push: container
 
 clean:
 	docker rmi $(PREFIX):$(TAG)
+
+tarball:
+	docker create -ti --name pac-tarball $(PREFIX):$(TAG) sh
+	docker cp pac-tarball:/home/appuser/ dest/
+	docker rm -f pac-tarball
+	tar -czvf pulsar-admin-console-$(TAG).tar.gz dest/

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ clean:
 	docker rmi $(PREFIX):$(TAG)
 
 tarball:
+	rm -rf dest/
 	docker create -ti --name pac-tarball $(PREFIX):$(TAG) sh
 	docker cp pac-tarball:/home/appuser/ dest/
 	docker rm -f pac-tarball
-	tar -czvf pulsar-admin-console-$(TAG).tar.gz dest/
+	tar -czf pulsar-admin-console-$(TAG).tar.gz dest/
+	rm -r dest/
+	openssl dgst -sha512 pulsar-admin-console-$(TAG).tar.gz

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,8 +5,8 @@
 Here is the high level process. See other sections of this page for details on how each step works.
 
 1. Push git tag to GitHub repo.
-2. Once Docker Hub has the new image, pull that image to your local machine and run `make tarball`.
-3. Run `openssl dgst -sha512 pulsar-admin-console-v0.0.4.tar.gz` (using the correct version).
+2. Once Docker Hub has the new image, pull that image to your local machine and run `make tarball TAG=1.1.4` (use the correct tag).
+3. Run `openssl dgst -sha512 pulsar-admin-console-1.1.4.tar.gz` (use the correct version).
 4. Create the GitHub release page. Upload the tarball and make sure the release notes include the tarball's checksum and a reference to the docker image for the release.
 
 ## How to build a Docker release image

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,9 +5,8 @@
 Here is the high level process. See other sections of this page for details on how each step works.
 
 1. Push git tag to GitHub repo.
-2. Once Docker Hub has the new image, pull that image to your local machine and run `make tarball TAG=1.1.4` (use the correct tag).
-3. Run `openssl dgst -sha512 pulsar-admin-console-1.1.4.tar.gz` (use the correct version).
-4. Create the GitHub release page. Upload the tarball and make sure the release notes include the tarball's checksum and a reference to the docker image for the release.
+2. Once Docker Hub has the new image, pull that image to your local machine and run `make tarball TAG=1.1.4` (use the correct tag). The resulting tarball will be named `pulsar-admin-console-$(TAG).tar.gz`.
+3. Create the GitHub release page. Upload the tarball and make sure the release notes include the tarball's checksum and a reference to the docker image for the release. (The checksum is printed out as part of running `make tarball`.)
 
 ## How to build a Docker release image
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ Here is the high level process. See other sections of this page for details on h
 1. Push git tag to GitHub repo.
 2. Once Docker Hub has the new image, pull that image to your local machine and run `make tarball`.
 3. Run `openssl dgst -sha512 pulsar-admin-console-v0.0.4.tar.gz` (using the correct version).
-4. Create the GitHub release page. Upload the tarball and make sure the release notes include the tarball's checksum.
+4. Create the GitHub release page. Upload the tarball and make sure the release notes include the tarball's checksum and a reference to the docker image for the release.
 
 ## How to build a Docker release image
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,14 @@
 # Release
 
+## Release Process
+
+Here is the high level process. See other sections of this page for details on how each step works.
+
+1. Push git tag to GitHub repo.
+2. Once Docker Hub has the new image, pull that image to your local machine and run `make tarball`.
+3. Run `openssl dgst -sha512 pulsar-admin-console-v0.0.4.tar.gz` (using the correct version).
+4. Create the GitHub release page. Upload the tarball and make sure the release notes include the tarball's checksum.
+
 ## How to build a Docker release image
 
 Docker release image is built by the automated Docker Hub build process. The build is triggered by Github remote tagging.


### PR DESCRIPTION
Add a `make tarball` command to create a tarball for non-docker distribution. I update the RELEASE.md to ensure the new process includes releasing artifacts.