### PR TITLE
Run npx browserslist@latest --update-db for dashboard

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -2519,12 +2519,6 @@
             }
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001300",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-          "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -4000,14 +3994,6 @@
             "electron-to-chromium": "^1.3.723",
             "escalade": "^3.1.1",
             "node-releases": "^1.1.71"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001242",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-              "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
-              "dev": true
-            }
           }
         },
         "electron-to-chromium": {
@@ -4678,14 +4664,6 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
-      },
-      "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001300",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-          "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
-          "dev": true
-        }
       }
     },
     "buffer": {
@@ -5011,12 +4989,6 @@
             "node-releases": "^1.1.71"
           },
           "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001242",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-              "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
-              "dev": true
-            },
             "electron-to-chromium": {
               "version": "1.3.768",
               "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",
@@ -5034,9 +5006,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000890",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000890.tgz",
-      "integrity": "sha512-4NI3s4Y6ROm+SgZN5sLUG4k7nVWQnedis3c/RWkynV5G6cHSY7+a8fwFyn2yoBDE3E6VswhTNNwR3PvzGqlTkg==",
+      "version": "1.0.30001300",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
+      "integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -6136,12 +6108,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.71"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001242",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-          "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
-          "dev": true
         },
         "cssesc": {
           "version": "3.0.0",
@@ -13080,12 +13046,6 @@
             "node-releases": "^1.1.71"
           },
           "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001242",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-              "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
-              "dev": true
-            },
             "electron-to-chromium": {
               "version": "1.3.768",
               "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",
@@ -15086,12 +15046,6 @@
             "node-releases": "^1.1.71"
           },
           "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001242",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-              "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
-              "dev": true
-            },
             "electron-to-chromium": {
               "version": "1.3.768",
               "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz",


### PR DESCRIPTION
When building the dashboard, we get the following errors:

```
⠏  Building for production...Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```

I ran `npx browserslist@latest --update-db` in the `dashboard/` directory and these are the resulting changes. They seem reasonable, so I am merging them now.

Note: when re-running the command to build the dashboard (`npm run build-standalone`), this warning is no longer present. 