### PR TITLE
Fix naming validation: allow =.: in names

### DIFF
--- a/dashboard/src/components/admin/app-navbar/AppNavbar.vue
+++ b/dashboard/src/components/admin/app-navbar/AppNavbar.vue
@@ -31,13 +31,13 @@
                     name="Tenant Name"
                     ref="tenantName"
                     v-model="tenantName"
-                    v-validate="'required|alpha_dash|min:1'"
+                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                     required
                   />
                   <label class="control-label" for="tenantName">Tenant Name</label><i class="bar"></i>
                   <small v-show="errors.has('Tenant Name')"
                         class="help text-danger">
-                  {{ errors.first('Tenant Name') }}
+                  {{ errors.first('Tenant Name') ? 'Tenant name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
                 </small>
                 </div>
             </div>

--- a/dashboard/src/components/admin/app-navbar/AppNavbar.vue
+++ b/dashboard/src/components/admin/app-navbar/AppNavbar.vue
@@ -31,13 +31,13 @@
                     name="Tenant Name"
                     ref="tenantName"
                     v-model="tenantName"
-                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                    v-validate="namedEntityValidationRegex()"
                     required
                   />
                   <label class="control-label" for="tenantName">Tenant Name</label><i class="bar"></i>
                   <small v-show="errors.has('Tenant Name')"
                         class="help text-danger">
-                  {{ errors.first('Tenant Name') ? 'Tenant name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
+                  {{ errors.first('Tenant Name') ? namedEntityValidationError() : '' }}
                 </small>
                 </div>
             </div>

--- a/dashboard/src/components/clients/PulsarClient.vue
+++ b/dashboard/src/components/clients/PulsarClient.vue
@@ -78,7 +78,7 @@
                             <input id="produce-topic-input"
                             v-model="currentProduceTopic"
                             class="has-value"
-                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                             name="currentProduceTopic"
                             data-vv-as="Produce Topic"
                             />
@@ -93,7 +93,7 @@
                             <input id="subscription-input"
                             v-model="currentSubscription"
                             class="has-value"
-                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                             name="currentSubscription"
                             data-vv-as="Subscription"
                             />
@@ -132,7 +132,7 @@
                             <input id="consume-topic-input"
                             v-model="currentConsumeTopic"
                             class="has-value"
-                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                             name="currentConsumeTopic"
                             data-vv-as="Consume Topic"
                             />
@@ -157,7 +157,7 @@
                                 <input id="key"
                                 v-model="key"
                                 class="has-value"
-                                v-validate="{ required: false, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                v-validate="{ required: false, regex: /^[-=:.\w]*$/  }"
                                 name="key"
                                 data-vv-as="Key"
                                 />

--- a/dashboard/src/components/clusters/Clusters.vue
+++ b/dashboard/src/components/clusters/Clusters.vue
@@ -31,13 +31,13 @@
                     name="Tenant Name"
                     ref="tenantName"
                     v-model="tenantName"
-                    v-validate="'required|alpha_dash|min:1'"
+                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                     required
                   />
                   <label class="control-label" for="tenantName">Tenant Name</label><i class="bar"></i>
                   <small v-show="errors.has('Tenant Name')"
                         class="help text-danger">
-                  {{ errors.first('Tenant Name') }}
+                  {{ errors.first('Tenant Name') ? 'Tenant name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
                 </small>
                 </div>
             </div>

--- a/dashboard/src/components/clusters/Clusters.vue
+++ b/dashboard/src/components/clusters/Clusters.vue
@@ -31,13 +31,13 @@
                     name="Tenant Name"
                     ref="tenantName"
                     v-model="tenantName"
-                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                    v-validate="namedEntityValidationRegex()"
                     required
                   />
                   <label class="control-label" for="tenantName">Tenant Name</label><i class="bar"></i>
                   <small v-show="errors.has('Tenant Name')"
                         class="help text-danger">
-                  {{ errors.first('Tenant Name') ? 'Tenant name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
+                  {{ errors.first('Tenant Name') ? namedEntityValidationError() : '' }}
                 </small>
                 </div>
             </div>

--- a/dashboard/src/components/code-samples/Golang/GolangConsumer.vue
+++ b/dashboard/src/components/code-samples/Golang/GolangConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input" 
                                     v-model="currentSubscription" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Golang/GolangConsumer.vue
+++ b/dashboard/src/components/code-samples/Golang/GolangConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input" 
                                     v-model="currentSubscription" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Golang/GolangProducer.vue
+++ b/dashboard/src/components/code-samples/Golang/GolangProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Golang/GolangProducer.vue
+++ b/dashboard/src/components/code-samples/Golang/GolangProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Golang/GolangReader.vue
+++ b/dashboard/src/components/code-samples/Golang/GolangReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Golang/GolangReader.vue
+++ b/dashboard/src/components/code-samples/Golang/GolangReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/CurlConsumer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/CurlConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/CurlConsumer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/CurlConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/CurlProducer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/CurlProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/CurlProducer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/CurlProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/HttpClientsConsumer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/HttpClientsConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/HttpClientsConsumer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/HttpClientsConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/HttpClientsProducer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/HttpClientsProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/HttpClients/HttpClientsProducer.vue
+++ b/dashboard/src/components/code-samples/HttpClients/HttpClientsProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Java/JavaConsumer.vue
+++ b/dashboard/src/components/code-samples/Java/JavaConsumer.vue
@@ -54,7 +54,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -71,7 +71,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Java/JavaConsumer.vue
+++ b/dashboard/src/components/code-samples/Java/JavaConsumer.vue
@@ -54,7 +54,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -71,7 +71,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Java/JavaProducer.vue
+++ b/dashboard/src/components/code-samples/Java/JavaProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Java/JavaProducer.vue
+++ b/dashboard/src/components/code-samples/Java/JavaProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Java/JavaReader.vue
+++ b/dashboard/src/components/code-samples/Java/JavaReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Java/JavaReader.vue
+++ b/dashboard/src/components/code-samples/Java/JavaReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Nodejs/NodejsConsumer.vue
+++ b/dashboard/src/components/code-samples/Nodejs/NodejsConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Nodejs/NodejsConsumer.vue
+++ b/dashboard/src/components/code-samples/Nodejs/NodejsConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input"
                                     v-model="currentTopic"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input"
                                     v-model="currentSubscription"
                                     class="has-value"
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Nodejs/NodejsProducer.vue
+++ b/dashboard/src/components/code-samples/Nodejs/NodejsProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Nodejs/NodejsProducer.vue
+++ b/dashboard/src/components/code-samples/Nodejs/NodejsProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Nodejs/NodejsReader.vue
+++ b/dashboard/src/components/code-samples/Nodejs/NodejsReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Nodejs/NodejsReader.vue
+++ b/dashboard/src/components/code-samples/Nodejs/NodejsReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Python/PythonConsumer.vue
+++ b/dashboard/src/components/code-samples/Python/PythonConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input" 
                                     v-model="currentSubscription" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Python/PythonConsumer.vue
+++ b/dashboard/src/components/code-samples/Python/PythonConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input" 
                                     v-model="currentSubscription" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/Python/PythonProducer.vue
+++ b/dashboard/src/components/code-samples/Python/PythonProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Python/PythonProducer.vue
+++ b/dashboard/src/components/code-samples/Python/PythonProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Python/PythonReader.vue
+++ b/dashboard/src/components/code-samples/Python/PythonReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/Python/PythonReader.vue
+++ b/dashboard/src/components/code-samples/Python/PythonReader.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/WsPython/WsPythonConsumer.vue
+++ b/dashboard/src/components/code-samples/WsPython/WsPythonConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input" 
                                     v-model="currentSubscription" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/WsPython/WsPythonConsumer.vue
+++ b/dashboard/src/components/code-samples/WsPython/WsPythonConsumer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />
@@ -68,7 +68,7 @@
                                     <input id="subscription-input" 
                                     v-model="currentSubscription" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentSubscription"
                                     data-vv-as="Subscription"
                                     />

--- a/dashboard/src/components/code-samples/WsPython/WsPythonProducer.vue
+++ b/dashboard/src/components/code-samples/WsPython/WsPythonProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/WsPython/WsPythonProducer.vue
+++ b/dashboard/src/components/code-samples/WsPython/WsPythonProducer.vue
@@ -51,7 +51,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/WsPython/WsPythonReader.vue
+++ b/dashboard/src/components/code-samples/WsPython/WsPythonReader.vue
@@ -50,7 +50,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="'required|alpha_dash'"
+                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/code-samples/WsPython/WsPythonReader.vue
+++ b/dashboard/src/components/code-samples/WsPython/WsPythonReader.vue
@@ -50,7 +50,7 @@
                                     <input id="topic-input" 
                                     v-model="currentTopic" 
                                     class="has-value" 
-                                    v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                                    v-validate="namedEntityValidationRegex()"
                                     name="currentTopic"
                                     data-vv-as="Produce Topic"
                                     />

--- a/dashboard/src/components/functions/FunctionCreate.vue
+++ b/dashboard/src/components/functions/FunctionCreate.vue
@@ -54,7 +54,7 @@
                                     <div class="input-group">
                                         <input v-model="className"
                                             id="funcadd-classname"
-                                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                             data-vv-as="Class Name"
                                             name="funcadd-classname"
                                             placeholder="class"/>
@@ -80,7 +80,7 @@
                                   <input v-model="inputTopicToAdd"
                                       id="funcadd-intopic"
                                       name="funcadd-intopic"
-                                      v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                      v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                       data-vv-as="Input Topic"
                                       :placeholder="functionName ? functionName +'-input' : 'newFunction-input'"
                                       />
@@ -140,7 +140,7 @@
                                     <input v-model="functionName"
                                             id="funcadd-name"
                                             name="funcadd-name"
-                                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                             data-vv-as="Function Name"
                                             placeholder="newFunction"/>
                                             <i class="fa fa-times icon-right input-icon pointer"

--- a/dashboard/src/components/namespaces/Namespaces.vue
+++ b/dashboard/src/components/namespaces/Namespaces.vue
@@ -35,13 +35,13 @@
                           name="Namespace Name"
                           ref="namespaceName"
                           v-model="namespaceName"
-                          v-validate="'required|alpha_dash|min:1'"
+                          v-validate="namedEntityValidationRegex()"
                           required
                         />
                         <label class="control-label" for="namespaceName">Namespace Name</label><i class="bar"></i>
                         <small v-show="errors.has('Namespace Name')"
                              class="help text-danger">
-                        {{ errors.first('Namespace Name') }}
+                        {{ errors.first('Namespace Name') ? namedEntityValidationError() : '' }}
                       </small>
                       </div>
                   </div>

--- a/dashboard/src/components/sinks/SinkCreate.vue
+++ b/dashboard/src/components/sinks/SinkCreate.vue
@@ -40,7 +40,7 @@
                                     <input v-model="sinkName"
                                             id="sinkadd-name"
                                             name="sinkadd-name"
-                                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                             data-vv-as="Sink Name"
                                             placeholder="newSink"/>
                                             <i class="fa fa-times icon-right input-icon pointer"
@@ -337,7 +337,7 @@
                                   <input v-model="inputTopicToAdd"
                                       id="sinkadd-intopic"
                                       name="sinkadd-intopic"
-                                      v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                      v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                       data-vv-as="Input Topic"
                                       />
                                   <label class="control-label" for="sinkadd-intopic" role="button">Topic</label><i class="bar"></i>

--- a/dashboard/src/components/sources/SourceCreate.vue
+++ b/dashboard/src/components/sources/SourceCreate.vue
@@ -40,7 +40,7 @@
                                     <input v-model="sourceName"
                                             id="sourceadd-name"
                                             name="sourceadd-name"
-                                            v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                            v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                             data-vv-as="Source Name"
                                             placeholder="newSource"/>
                                             <i class="fa fa-times icon-right input-icon pointer"
@@ -310,7 +310,7 @@
                                   <input v-model="outputTopicToAdd"
                                       id="sourceadd-outtopic"
                                       name="sourceadd-intopic"
-                                      v-validate="{ required: true, regex: /^[a-zA-Z0-9_.-]+$/ }"
+                                      v-validate="{ required: true, regex: /^[-=:.\w]*$/  }"
                                       data-vv-as="Output Topic"
                                       />
                                   <label class="control-label" for="sourceadd-intopic" role="button">Topic</label><i class="bar"></i>

--- a/dashboard/src/components/topics/TopicSubscriptionsTab.vue
+++ b/dashboard/src/components/topics/TopicSubscriptionsTab.vue
@@ -44,13 +44,13 @@
                         name="subscriptionName"
                         ref="subscriptionName"
                         v-model="subToCreate"
-                        v-validate="'required|alpha_dash'"
+                        v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                         required
                         />
                         <label class="control-label" for="subscriptionName">Subscription Name</label><i class="bar"></i>
                         <small v-show="errors.has('subscriptionName')"
                             class="help text-danger">
-                        {{ errors.first('subscriptionName') }}
+                        {{ errors.first('subscriptionName') ? 'Subscription name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
                     </small>
                     </div>
                 </div>

--- a/dashboard/src/components/topics/TopicSubscriptionsTab.vue
+++ b/dashboard/src/components/topics/TopicSubscriptionsTab.vue
@@ -44,13 +44,13 @@
                         name="subscriptionName"
                         ref="subscriptionName"
                         v-model="subToCreate"
-                        v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                        v-validate="namedEntityValidationRegex()"
                         required
                         />
                         <label class="control-label" for="subscriptionName">Subscription Name</label><i class="bar"></i>
                         <small v-show="errors.has('subscriptionName')"
                             class="help text-danger">
-                        {{ errors.first('subscriptionName') ? 'Subscription name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
+                        {{ errors.first('subscriptionName') ? namedEntityValidationError() : '' }}
                     </small>
                     </div>
                 </div>

--- a/dashboard/src/components/topics/Topics.vue
+++ b/dashboard/src/components/topics/Topics.vue
@@ -47,13 +47,13 @@
                           name="Topic Name"
                           ref="topicName"
                           v-model="createTopicName"
-                          v-validate="'required|alpha_dash'"
+                          v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
                           required
                         />
                         <label class="control-label" for="topicName">Topic Name</label><i class="bar"></i>
                         <small v-show="errors.has('Topic Name')"
                              class="help text-danger">
-                        {{ errors.first('Topic Name') }}
+                        {{ errors.first('Topic Name') ? 'Topic name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
                       </small>
                       </div>
                   </div>

--- a/dashboard/src/components/topics/Topics.vue
+++ b/dashboard/src/components/topics/Topics.vue
@@ -47,13 +47,13 @@
                           name="Topic Name"
                           ref="topicName"
                           v-model="createTopicName"
-                          v-validate="{ required: true, regex: /^[-=:.\w]*$/ }"
+                          v-validate="namedEntityValidationRegex()"
                           required
                         />
                         <label class="control-label" for="topicName">Topic Name</label><i class="bar"></i>
                         <small v-show="errors.has('Topic Name')"
                              class="help text-danger">
-                        {{ errors.first('Topic Name') ? 'Topic name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods' : '' }}
+                        {{ errors.first('Topic Name') ? namedEntityValidationError() : '' }}
                       </small>
                       </div>
                   </div>

--- a/dashboard/src/services/mixins.js
+++ b/dashboard/src/services/mixins.js
@@ -80,6 +80,12 @@ export default {
       }
       return provider
     },
+    namedEntityValidationRegex () {
+      return { required: true, regex: /^[-=:.\w]*$/ };
+    },
+    namedEntityValidationError () {
+      return 'Name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods';
+    },
     splitClusterName (dataCenter) {
 
       let splitInfo = {

--- a/dashboard/src/services/mixins.js
+++ b/dashboard/src/services/mixins.js
@@ -51,6 +51,14 @@ export default {
       }
     }
   },
+  computed: {
+    namedEntityValidationRegex: function() {
+      return { required: true, regex: /^[-=:.\w]*$/ };
+    },
+    namedEntityValidationError: function() {
+      return 'Name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods';
+    },
+  },
   methods: {
     onCopy: function () {
       this.showToast('Copied', this.toastOptionsCopy)
@@ -79,12 +87,6 @@ export default {
         provider = 'Azure'
       }
       return provider
-    },
-    namedEntityValidationRegex () {
-      return { required: true, regex: /^[-=:.\w]*$/ };
-    },
-    namedEntityValidationError () {
-      return 'Name may contain alpha-numeric characters as well as underscores, dashes, equal signs, colons, and periods';
     },
     splitClusterName (dataCenter) {
 


### PR DESCRIPTION
Valid pulsar entity names are defined here:

https://github.com/apache/pulsar/blob/102fa9de03509b86e47f58ab8e1c0dde2095da3b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java#L30-L33

This PR enables support for `=`, `:`, and `.` in names.