### PR TITLE
Use clientToken as default authorization token

### DIFF
--- a/dashboard/src/components/clients/PulsarClient.vue
+++ b/dashboard/src/components/clients/PulsarClient.vue
@@ -416,7 +416,7 @@ export default {
       let token = ''
         if (this.authMode === 'k8s') {
           token = this.adminToken;
-        } else if (this.authMode === 'openidconnect')  {
+        } else {
           token = this.clientToken;
         } 
 

--- a/dashboard/src/services/ApiBase.js
+++ b/dashboard/src/services/ApiBase.js
@@ -25,7 +25,7 @@ export default() => {
   let token = ''
   if (store.getters.authMode === 'k8s') {
     token = store.getters.adminToken;
-  } else if (store.getters.authMode === 'openidconnect')  {
+  } else {
     token = store.getters.clientToken;
   } 
   

--- a/dashboard/src/services/ApiBaseV2.js
+++ b/dashboard/src/services/ApiBaseV2.js
@@ -23,7 +23,7 @@ export default() => {
   let token = ''
   if (store.getters.authMode === 'k8s') {
     token = store.getters.adminToken;
-  } else if (store.getters.authMode === 'openidconnect')  {
+  } else {
     token = store.getters.clientToken;
   } 
 


### PR DESCRIPTION
In #19, we restored support for using adminToken wih k8s authentication. However, this affected testing use cases where a user wants to see how the admin console works when running on a VM without an authentication mode but with a token protected Pulsar cluster.