### PR TITLE
Body-Parser and schema compatibility fix

### DIFF
--- a/dashboard/src/components/namespaces/NamespaceOverviewTab.vue
+++ b/dashboard/src/components/namespaces/NamespaceOverviewTab.vue
@@ -618,7 +618,7 @@ export default {
         const newStrat = this.namespacesConfig.data[this.$route.params.id].schema_compatibility_strategy
 
         if (!newStrat || newStrat === 'UNDEFINED') {
-          return oldStrat.toUpperCase()
+          return oldStrat ? oldStrat.toUpperCase() : 'UNDEFINED'
         }
         return newStrat
       }

--- a/dashboard/src/store/modules/pulsar.js
+++ b/dashboard/src/store/modules/pulsar.js
@@ -1279,10 +1279,11 @@ const actions = {
           const newStrat = state.namespacesConfig.data[nsIdx].schema_compatibility_strategy
 
           if (!newStrat || newStrat === 'UNDEFINED') {
-            compatMode = oldStrat.toUpperCase()
+            compatMode = oldStrat ? oldStrat.toUpperCase() : 'UNDEFINED'
           } else {
             compatMode = newStrat
           }
+          console.log(compatMode)
           if (state.namespacesConfig.data[nsIdx].backlog_quota_map.destination_storage) {
             // Name of property changed in 2.8. Making sure the admin console can work before and after 2.8
             if (state.namespacesConfig.data[nsIdx].backlog_quota_map.destination_storage.limit) {

--- a/server/server.js
+++ b/server/server.js
@@ -70,7 +70,7 @@ const isUserAuthenticated = async (username, password) => {
 // place holder for the user data
 const users = [];
 
-app.use(bodyParser.json());
+app.use(bodyParser.json({ strict: false}));
 
 app.use('/ws/', createProxyMiddleware({
   target: cfg.globalConf.server_config.websocket_url,


### PR DESCRIPTION
- Removes `body-parser`'s strict mode (which only allows for json bodies to be arrays or objects)
- Handles both new and old schema compatibility strategy fields in the namespace policies call
