### PR TITLE
Forward to the function worker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ In a geo-replication configuration, you will want to use the cluster name for th
 | server_config.port | 6454 | The listen port for the console server |
 | server_config.pulsar_url | http://localhost:8080 | URL for connecting to the Pulsar cluster. Should point to either a broker or Pulsar proxy. The console server must be able to reach this URL. 
 | server_config.websocket_url | https://websocket.example.com:8500 | URL for WebSocket proxy. Used by Test Clients to connect to Pulsar. The console server must be able to reach this URL. 
+| server_config.function_worker_url | `""` | URL for function worker. The default value of `""` means that the server will proxy all function/sink/source calls to the `pulsar_url`. This only needs to be set when the `pulsar_url` cannot handle function/sink/source requests. The console server must be able to reach this URL.
 | server_config.log_level | info | Log level for the console server
 | server_config.token_path |  | When using `user` or `k8s` auth mode, a Pulsar token is used to connect to the Pulsar cluster. This specifies the path to a file that contains the token to use. For full access, a superuser token is recommended. Alternatively, use `admin_token`. |
 | server_config.admin_token | | When using `user` or `k8s` auth mode, a Pulsar token is used to connect to the Pulsar cluster. This specifies the token as a string. For full access, a superuser token is recommended. The `token_path` setting will override this value if present.|

--- a/config/default.json
+++ b/config/default.json
@@ -7,6 +7,7 @@
         "port": "6454",
         "pulsar_url": "http://localhost:8080",
         "websocket_url": "https://websocket.example.com:8500",
+        "function_worker_url": "",
         "log_level": "info",
         "token_path": "",
         "admin_token": "",

--- a/server/server.js
+++ b/server/server.js
@@ -164,9 +164,12 @@ const onProxyRes = (proxyRes, req, res) => {
   }
 };
 
+// If function work URL is defined, use for function path, otherwise use Pulsar URL
+const functionUrl = cfg.globalConf.server_config.function_worker_url ? cfg.globalConf.server_config.function_worker_url : cfg.globalConf.server_config.pulsar_url
+
 // Proxies
 app.use(`/api/v1/${cluster}/functions`, createProxyMiddleware({
-  target: cfg.globalConf.server_config.pulsar_url,
+  target: functionUrl,
   pathRewrite: connectorPathRewrite,
   onProxyReq,
   onProxyRes,
@@ -175,7 +178,7 @@ app.use(`/api/v1/${cluster}/functions`, createProxyMiddleware({
 }));
 
 app.use(`/api/v1/${cluster}/sinks`, createProxyMiddleware({
-  target: cfg.globalConf.server_config.pulsar_url,
+  target: functionUrl,
   pathRewrite: connectorPathRewrite,
   onProxyReq,
   onProxyRes,
@@ -184,7 +187,7 @@ app.use(`/api/v1/${cluster}/sinks`, createProxyMiddleware({
 }));
 
 app.use(`/api/v1/${cluster}/sources`, createProxyMiddleware({
-  target: cfg.globalConf.server_config.pulsar_url,
+  target: functionUrl,
   pathRewrite: connectorPathRewrite,
   onProxyReq,
   onProxyRes,


### PR DESCRIPTION
If specified, forward function/sink/source call to the function worker URL. Otherwise, use the Pulsar URL (functions running in the broker).