### PR TITLE
Use secure defaults for TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ official Node.js documentation for additional details.
 | server_config.token_path |  | When using `user` or `k8s` auth mode, a Pulsar token is used to connect to the Pulsar cluster. This specifies the path to a file that contains the token to use. For full access, a superuser token is recommended. Alternatively, use `admin_token`. |
 | server_config.admin_token | | When using `user` or `k8s` auth mode, a Pulsar token is used to connect to the Pulsar cluster. This specifies the token as a string. For full access, a superuser token is recommended. The `token_path` setting will override this value if present.|
 | server_config.token_secret| | Secret used when signing access token for logging into the console. If not specified, a default secret is used |
-| server_config.ssl.verify_certs | false | Verify TLS certificate is trusted |
-| server_config.ssl.hostname_validation | | Verify hostname matches the TLS certificate |
+| server_config.ssl.verify_certs | `true` | Verify TLS certificate is trusted |
+| server_config.ssl.hostname_validation | `true` | Verify hostname matches the TLS certificate |
 | server_config.ssl.ca_path | | Path to the CA certificate. To enable HTTPS, `ca_path`, `cert_path`, and `key_path` must all be set |
 | server_config.ssl.cert_path | | Path to the server certificate. To enable HTTPS, `ca_path`, `cert_path`, and `key_path` must all be set |
 | server_config.ssl.key_path | | Path to the TLS key. To enable HTTPS, `ca_path`, `cert_path`, and `key_path` must all be set |

--- a/config/default.json
+++ b/config/default.json
@@ -12,8 +12,8 @@
         "admin_token": "",
         "token_secret": "",
         "ssl": {
-            "verify_certs": false,
-            "hostname_validation": false,
+            "verify_certs": true,
+            "hostname_validation": true,
             "ca_path": "",
             "cert_path": "",
             "key_path": ""

--- a/server/server.js
+++ b/server/server.js
@@ -76,6 +76,7 @@ app.use('/ws/', createProxyMiddleware({
   target: cfg.globalConf.server_config.websocket_url,
   ws: true,
   secure: cfg.globalConf.server_config.ssl.verify_certs,
+  changeOrigin: true // necessary for hostname verification to pass because of the `Host` header.
 }));
 
 const connectorPathRewrite = (path, req) => {
@@ -141,6 +142,9 @@ const onProxyRes = (proxyRes, req, res) => {
   if (proxyRes?.headers?.location) {
     const headers = req.headers;
     const body = req.body;
+
+    // Rewrite host header to support hostname verification.
+    headers.host = new URL(proxyRes.headers.location).host
 
     axios({
       url: proxyRes.headers.location,

--- a/server/server.js
+++ b/server/server.js
@@ -171,7 +171,8 @@ app.use(`/api/v1/${cluster}/functions`, createProxyMiddleware({
   onProxyReq,
   onProxyRes,
   secure: cfg.globalConf.server_config.ssl.verify_certs,
-  selfHandleResponse: true
+  selfHandleResponse: true,
+  changeOrigin: true // necessary for hostname verification to pass because of the `Host` header.
 }));
 
 app.use(`/api/v1/${cluster}/sinks`, createProxyMiddleware({
@@ -180,7 +181,8 @@ app.use(`/api/v1/${cluster}/sinks`, createProxyMiddleware({
   onProxyReq,
   onProxyRes,
   secure: cfg.globalConf.server_config.ssl.verify_certs,
-  selfHandleResponse: true
+  selfHandleResponse: true,
+  changeOrigin: true // necessary for hostname verification to pass because of the `Host` header.
 }));
 
 app.use(`/api/v1/${cluster}/sources`, createProxyMiddleware({
@@ -189,7 +191,8 @@ app.use(`/api/v1/${cluster}/sources`, createProxyMiddleware({
   onProxyReq,
   onProxyRes,
   secure: cfg.globalConf.server_config.ssl.verify_certs,
-  selfHandleResponse: true
+  selfHandleResponse: true,
+  changeOrigin: true // necessary for hostname verification to pass because of the `Host` header.
 }));
 
 if (cfg.globalConf.auth_mode === 'openidconnect' && cfg.globalConf.server_config.oauth2.grant_type === 'password') {
@@ -197,7 +200,9 @@ if (cfg.globalConf.auth_mode === 'openidconnect' && cfg.globalConf.server_config
     target: cfg.globalConf.server_config.oauth2.identity_provider_url,
     pathFilter: '/api/v1/auth/token',
     pathRewrite: {'^/api/v1/auth/token': cfg.globalConf.server_config.oauth2.token_endpoint},
-    changeOrigin: true, // By changingOrigin, we're able to make internal k8s networking work for the token
+    changeOrigin: true, // Necessary for hostname verification to pass because of the `Host` header. Also, note
+                        // that this has the side effect of making the JWT have the issuer from the proxy's perspective.
+                        // That is helpful when running with a Kubernetes based issuer.
   }))
 }
 
@@ -207,7 +212,8 @@ app.use(`/api/v1/${cluster}`, createProxyMiddleware({
   onProxyReq,
   onProxyRes,
   secure: cfg.globalConf.server_config.ssl.verify_certs,
-  selfHandleResponse: true
+  selfHandleResponse: true,
+  changeOrigin: true // necessary for hostname verification to pass because of the `Host` header.
 }))
 
 app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
It is safer to default to secure TLS defaults. Then, users can override the defaults, if necessary.

In the process of testing this PR, I discovered that the proxying of requests failed with the following error:

> [HPM] Error occurred while proxying request pulsar-adminconsole/admin/v2/namespaces/public to https://pulsar-proxy.test.svc.cluster.local:8443/ [ERR_TLS_CERT_ALTNAME_INVALID] (https://nodejs.org/api/errors.
html#errors_common_system_errors)

The certificate had the correct alt name, and after digging deeper, I can see that the issue is a mismatched `Host` header. Here is a stack overflow link that corroborates this theory: https://stackoverflow.com/questions/43175060/proxying-requests-in-node.

The solution is to use the `changeOrigin` option, which replaces the `Host` header with the correct one.

Note: this was not a security vulnerability. It was the opposite. Hostname verification always failed, even when it should have passed.