### PR TITLE
server: enable proxy log config

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -31,7 +31,6 @@ const bodyParser = require('body-parser');
 cfg.L.debug('Global config ', cfg.globalConf)
 require('dotenv').config()
 
-
 let k8s = ''
 const cluster = cfg.globalConf.home_cluster;
 
@@ -44,7 +43,6 @@ if (cfg.globalConf.auth_mode === "k8s") {
 
 const app = express(),
       cookieSession = require('cookie-session');
-
 
 const isUserAuthenticated = async (username, password) => {
 
@@ -73,6 +71,7 @@ const users = [];
 app.use(bodyParser.json({ strict: false}));
 
 app.use('/ws/', createProxyMiddleware({
+  logLevel: cfg.globalConf.server_config.log_level,
   target: cfg.globalConf.server_config.websocket_url,
   ws: true,
   secure: cfg.globalConf.server_config.ssl.verify_certs,
@@ -173,6 +172,7 @@ const functionUrl = cfg.globalConf.server_config.function_worker_url ? cfg.globa
 
 // Proxies
 app.use(`/api/v1/${cluster}/functions`, createProxyMiddleware({
+  logLevel: cfg.globalConf.server_config.log_level,
   target: functionUrl,
   pathRewrite: connectorPathRewrite,
   onProxyReq,
@@ -183,6 +183,7 @@ app.use(`/api/v1/${cluster}/functions`, createProxyMiddleware({
 }));
 
 app.use(`/api/v1/${cluster}/sinks`, createProxyMiddleware({
+  logLevel: cfg.globalConf.server_config.log_level,
   target: functionUrl,
   pathRewrite: connectorPathRewrite,
   onProxyReq,
@@ -193,6 +194,7 @@ app.use(`/api/v1/${cluster}/sinks`, createProxyMiddleware({
 }));
 
 app.use(`/api/v1/${cluster}/sources`, createProxyMiddleware({
+  logLevel: cfg.globalConf.server_config.log_level,
   target: functionUrl,
   pathRewrite: connectorPathRewrite,
   onProxyReq,
@@ -204,6 +206,7 @@ app.use(`/api/v1/${cluster}/sources`, createProxyMiddleware({
 
 if (cfg.globalConf.auth_mode === 'openidconnect' && cfg.globalConf.server_config.oauth2.grant_type === 'password') {
   app.use('/api/v1/auth/token', createProxyMiddleware({
+    logLevel: cfg.globalConf.server_config.log_level,
     target: cfg.globalConf.server_config.oauth2.identity_provider_url,
     pathFilter: '/api/v1/auth/token',
     pathRewrite: {'^/api/v1/auth/token': cfg.globalConf.server_config.oauth2.token_endpoint},
@@ -214,6 +217,7 @@ if (cfg.globalConf.auth_mode === 'openidconnect' && cfg.globalConf.server_config
 }
 
 app.use(`/api/v1/${cluster}`, createProxyMiddleware({
+  logLevel: cfg.globalConf.server_config.log_level,
   target: cfg.globalConf.server_config.pulsar_url,
   pathRewrite: rootPathRewrite,
   onProxyReq,


### PR DESCRIPTION
Apply the global log level to each of the proxies, so that it can be configured in the local config file.
