### PR TITLE
[Bug Fix] Forward response headers so front end can correctly handle content-encoding

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -102,7 +102,11 @@ app.use('/api/v1/brokerPath/', (req, res, next) => {
     res.status(resp.status).send(JSON.stringify(resp.data))
   }).catch((error) => {
     console.error(error);
-    res.status(error.response.status).send(error.response.data)
+    if(error.response){
+      res.status(error.response.status).send(error.response.data)
+    }else{
+      res.status(500).send(error.response?.data)
+    }
   })
 })
 
@@ -147,6 +151,11 @@ const onProxyRes = (proxyRes, req, res) => {
   if (proxyRes?.statusCode >= 400) {
     cfg.L.warn('proxy request failed with status ' + proxyRes.statusCode + ', url: \'' + proxyRes.req.host + proxyRes.req.path + '\'')
   }
+
+  // set the response headers so that the frontend can decode the content
+  Object.keys(proxyRes.headers).forEach((key) => {
+    res.setHeader(key, proxyRes.headers[key]);
+  });
 
   if (proxyRes?.headers?.location) {
     const headers = req.headers;


### PR DESCRIPTION
The pulsar REST api returns data that is gzip encoded. The front end needs to see the content-encoding header in order to decode the data. Previously the content-encoding header was not forwarded to the front end and it did not do this which caused it to malfunction. I added some code in the proxy that forwards the api response headers to the front end and now  the front end correctly decodes the response data. 

I also added another fix that returns error 500 if the proxy encounters an unknown error when trying to make the request. Previously it would crash because it was trying to access the status property that didn't exist. 