### PR TITLE
AS-3979: Updated the release repo to cloudtools repo

### DIFF
--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.CLOUD_TOOLS_USERNAME }}
+          password: ${{ secrets.CLOUD_TOOLS_PASSWORD }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -47,4 +47,4 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: docker.io/datastax/pulsar-admin-console:${{ env.TAG }}
+          tags: registry.cloud-tools.datastax.com/datastax/pulsar-admin-console:${{ env.TAG }}

--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -13,6 +13,10 @@ on:
         required: true
         default: 'dev'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-container-image.yml
+++ b/.github/workflows/release-container-image.yml
@@ -20,8 +20,17 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.CLOUD_TOOLS_USERNAME }}
-          password: ${{ secrets.CLOUD_TOOLS_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -47,4 +56,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: registry.cloud-tools.datastax.com/datastax/pulsar-admin-console:${{ env.TAG }}
+          tags: |
+            ${{ secrets.ECR_REGISTRY }}/datastax/pulsar-admin-console:${{ env.TAG }}
+            docker.io/datastax/pulsar-admin-console:${{ env.TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ WORKDIR /home/appuser/
 USER 10001:0
 
 RUN mkdir -p dashboard/dist && mkdir server && mkdir config && ls
-COPY --from=UI-BUILD --chown=10001:0 /build/dist /home/appuser/dashboard/dist
+COPY --from=ui-build --chown=10001:0 /build/dist /home/appuser/dashboard/dist
 COPY --chown=10001:0 config/default.json /home/appuser/config/
 COPY --chown=10001:0 server/package*.json /home/appuser/server/
 COPY --chown=10001:0 server/*.js /home/appuser/server/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as UI-BUILD
+FROM node:16 AS ui-build
 
 WORKDIR /build
 
@@ -35,7 +35,7 @@ WORKDIR /home/appuser/server
 
 # OpenShift compatibility
 RUN chmod g+w /home/appuser
-ENV HOME /home/appuser
+ENV HOME=/home/appuser
 
 EXPOSE 8080 8081 6454 6455
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   #     - './localhost.key:/certs/localhost.key'
   dashboard:
     container_name: dashboard 
-    image: datastax/pulsar-admin-console
+    image: registry.cloud-tools.datastax.com/datastax/pulsar-admin-console
     expose:
       - '80'
     # depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   #     - './localhost.key:/certs/localhost.key'
   dashboard:
     container_name: dashboard 
-    image: registry.cloud-tools.datastax.com/datastax/pulsar-admin-console
+    image: datastax/pulsar-admin-console
     expose:
       - '80'
     # depends_on:


### PR DESCRIPTION
These changes will ensure that the newer release images of pulsar-admin-console will be available in cloud-tools repository, which earlier were coming from docker.io
https://datastax.jira.com/browse/AS-3979